### PR TITLE
fix(type): lacks return-type annotation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,7 +111,7 @@ export declare interface Chart {
   setTechnicalIndicatorType(technicalIndicatorType: string, isStack?: boolean, paneId?: string): void;
   getTechnicalIndicatorType(paneId?: string): string[];
   createPane(type?: PaneType, options?: PaneOptions): string | null;
-  addCustomTechnicalIndicator(technicalIndicatorInfo: TechnicalIndicatorInfo)
+  addCustomTechnicalIndicator(technicalIndicatorInfo: TechnicalIndicatorInfo): void;
   removeTechnicalIndicator(technicalIndicatorType?: string, paneId?: string): void;
   addGraphicMark(graphicMarkType: GraphicMarkType): void;
   removeAllGraphicMark(): void;


### PR DESCRIPTION
Hi, 'addCustomTechnicalIndicator', which lacks return-type annotation, implicitly has an 'any' return type.

I had fixed. Could you approve this pull request

Thanks.


issue: https://github.com/liihuu/KLineChart/issues/60
