### PR TITLE
features: styleOptions.showArrow + added watermark

### DIFF
--- a/src/data/options/styleOptions.js
+++ b/src/data/options/styleOptions.js
@@ -470,6 +470,16 @@ const defaultSeparator = {
   activeBackgroundColor: 'rgba(33, 150, 243, 0.08)'
 }
 
+
+const defaultWatermark = {
+  show: false,
+  text: 'BTC/USDT',
+  color: 'rgba(255, 255, 255, 0.3)',
+  size: 55,
+  family: 'Helvetica',
+  weight: 'bold',
+}
+
 export const defaultStyleOptions = {
   grid: defaultGrid,
   candle: defaultCandle,
@@ -478,5 +488,6 @@ export const defaultStyleOptions = {
   yAxis: defaultYAxis,
   separator: defaultSeparator,
   crosshair: defaultCrosshair,
-  graphicMark: defaultGraphicMark
+  graphicMark: defaultGraphicMark,
+  watermark: defaultWatermark
 }

--- a/src/data/options/styleOptions.js
+++ b/src/data/options/styleOptions.js
@@ -131,6 +131,7 @@ const defaultCandle = {
   },
   priceMark: {
     show: true,
+    showArrow: true,
     high: {
       show: true,
       color: '#D9D9D9',

--- a/src/view/CandleView.js
+++ b/src/view/CandleView.js
@@ -174,25 +174,29 @@ export default class CandleView extends TechnicalIndicatorView {
     this._ctx.strokeStyle = lowHighPriceMarkOptions.color
     this._ctx.fillStyle = lowHighPriceMarkOptions.color
 
-    renderLine(this._ctx, () => {
-      this._ctx.beginPath()
-      this._ctx.moveTo(startX - 2, startY + offsets[0])
-      this._ctx.lineTo(startX, startY)
-      this._ctx.lineTo(startX + 2, startY + offsets[0])
-      this._ctx.stroke()
-      this._ctx.closePath()
-    })
 
-    // 绘制竖线
     const y = startY + offsets[1]
-    renderLine(this._ctx, () => {
-      this._ctx.beginPath()
-      this._ctx.moveTo(startX, startY)
-      this._ctx.lineTo(startX, y)
-      this._ctx.lineTo(startX + 5, y)
-      this._ctx.stroke()
-      this._ctx.closePath()
-    })
+
+    if (priceMarkOptions.showArrow) {
+      renderLine(this._ctx, () => {
+        this._ctx.beginPath()
+        this._ctx.moveTo(startX - 2, startY + offsets[0])
+        this._ctx.lineTo(startX, startY)
+        this._ctx.lineTo(startX + 2, startY + offsets[0])
+        this._ctx.stroke()
+        this._ctx.closePath()
+      })
+
+      // 绘制竖线
+      renderLine(this._ctx, () => {
+        this._ctx.beginPath()
+        this._ctx.moveTo(startX, startY)
+        this._ctx.lineTo(startX, y)
+        this._ctx.lineTo(startX + 5, y)
+        this._ctx.stroke()
+        this._ctx.closePath()
+      })
+    }
 
     this._ctx.font = createFont(lowHighPriceMarkOptions.textSize, lowHighPriceMarkOptions.textWeight, lowHighPriceMarkOptions.textFamily)
     const text = formatPrecision(price, pricePrecision)

--- a/src/view/CandleView.js
+++ b/src/view/CandleView.js
@@ -46,6 +46,20 @@ export default class CandleView extends TechnicalIndicatorView {
     }
     this._drawTechnicalIndicators()
     this._drawLastPriceLine(candleOptions.priceMark)
+    this._drawWatermark()
+  }
+
+  _drawWatermark() {
+    const watermarkOptions = this._chartData.styleOptions().watermark
+
+    if (!watermarkOptions.show) return
+
+    this._ctx.save()
+    this._ctx.textAlign = 'center';
+    this._ctx.fillStyle = watermarkOptions.color;
+    this._ctx.font = `${watermarkOptions.weight} ${watermarkOptions.size}px ${watermarkOptions.family}`
+    this._ctx.fillText(watermarkOptions.text, this._width / 2, this._height / 2)
+    this._ctx.restore()
   }
 
   /**


### PR DESCRIPTION
Hello,
I added the possibility to not display the small arrows of the low/high price.
I also added the drawWatermark function which allows to display a watermark on the chart as proposed by some other libraries. Its display is disabled by default.
![btcusdt](https://user-images.githubusercontent.com/8337858/106400976-ded2fe00-6421-11eb-9591-a607695afe65.PNG)

If you accept the merge, and if necessary, I can update the documentation