### PR TITLE
Add regeneratePlots function to RSI

### DIFF
--- a/src/extension/technicalindicator/oscillators/relativeStrengthIndex.js
+++ b/src/extension/technicalindicator/oscillators/relativeStrengthIndex.js
@@ -25,6 +25,11 @@ export default {
     { key: 'rsi12', title: 'RSI12', type: 'line' },
     { key: 'rsi24', title: 'RSI24', type: 'line' }
   ],
+  regeneratePlots: (params) => {
+    return params.map(p => {
+      return { key: `rsi${p}`, title: `RSI${p}`, type: 'line' }
+    })
+  },
   calcTechnicalIndicator: (dataList, calcParams, plots) => {
     const sumCloseAs = []
     const sumCloseBs = []


### PR DESCRIPTION
Hi,

I believe there should be a default regeneratePlots function for RSI chart. Could you please consider to merge this PR.
Thanks.
