### PR TITLE
Update graphicHelper.js

### DIFF
--- a/src/extension/mark/graphicHelper.js
+++ b/src/extension/mark/graphicHelper.js
@@ -92,7 +92,7 @@ export function checkPointOnStraightLine (point1, point2, targetPoint) {
   const kb = getLinearSlopeIntercept(point1, point2)
   const y = getLinearYFromSlopeIntercept(kb, targetPoint)
   const yDif = Math.abs(y - targetPoint.y)
-  return yDif * yDif / (kb.k * kb.k + 1) < DEVIATION * DEVIATION
+  return yDif * yDif / (kb.k * kb.k + 10) < DEVIATION * DEVIATION
 }
 
 /**


### PR DESCRIPTION
Extend the hover area of marks issue#99

Currently, in order to select a marking like a ray-line, one needs to know exactly where the marked points are and hover over it. The hover area should be extended to the entire line(s) and a few pixels near the line to make selecting it easier. Bonus, the cursor should be changed to pointer when hover over a marking for good UX as well.