### PR TITLE
feat: can now add ticks with applyMoreData

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -100,6 +100,10 @@ export default class Chart {
     this._chartPane.adjustPaneViewport(true, true, true, true, true)
   }
 
+  setIntervalMs (intervalMs) {
+    this._chartPane.chartData().setIntervalMs(intervalMs)
+  }
+
   /**
    * 设置右边间距
    * @param space 空间大小
@@ -205,13 +209,22 @@ export default class Chart {
    * @param dataList k线数据数组
    * @param more 是否还有更多标识
    */
-  applyMoreData (dataList, more) {
-    if (!isArray(dataList)) {
-      logWarn('applyMoreData', 'dataList', 'dataList must be an array!!!')
+  applyMoreData (data, more) {
+    const isAnArray = isArray(data)
+    const isObjectAndHaveGoodFormat = isObject(data) && data.timestamp && data.price
+    if (!isAnArray && !isObjectAndHaveGoodFormat) {
+      logWarn('applyMoreData', 'data', 'data must be an array of an object with `timestamp` and `price` properties.')
       return
     }
+
     const chartData = this._chartPane.chartData()
-    chartData.addData(dataList, 0, more)
+    if (isAnArray) {
+      chartData.addData(data, 0, more)
+    } else {
+      chartData.addTick(data)
+      this._chartPane.adjustPaneViewport(false, false, true)
+    }
+
     Promise.resolve(chartData.technicalIndicatorStore().calcInstance()).then(
       result => {
         if (result) {

--- a/src/data/ChartData.js
+++ b/src/data/ChartData.js
@@ -156,7 +156,7 @@ export default class ChartData {
       return logWarn(null, null, 'You must define the timeframe to add ticks !')
     }
 
-    const now = tickData.t
+    const now = tickData.timestamp || (new Date()).getTime()
     if (!last) last = [now - (now % tf)]
     const tNext = last.timestamp + tf
     const t = now >= tNext ? now - (now % tf) : last.timestamp

--- a/src/data/ChartData.js
+++ b/src/data/ChartData.js
@@ -147,7 +147,8 @@ export default class ChartData {
   }
 
   addTick (tickData) {
-    let last = this._dataList[this._dataList.length - 1]
+    const dataSize = this._dataList.length
+    let last = this._dataList[dataSize - 1]
     const tickPrice = tickData.price
     const volume = tickData.volume || 0
 
@@ -161,17 +162,15 @@ export default class ChartData {
     const tNext = last.timestamp + tf
     const t = now >= tNext ? now - (now % tf) : last.timestamp
 
-    if ((t >= tNext || !this._dataList.length) && tickPrice !== undefined) {
-      this.addData([
-        {
+    if ((t >= tNext || !dataSize) && tickPrice !== undefined) {
+      this.addData({
           timestamp: t,
           open: tickPrice,
           high: tickPrice,
           low: tickPrice,
           close: tickPrice,
           volume: volume
-        }
-      ])
+        }, dataSize)
     } else if (tickPrice !== undefined) {
       last.high = Math.max(tickPrice, last.high)
       last.low = Math.min(tickPrice, last.low)


### PR DESCRIPTION
With this PR we can now add ticks as well as candles to the chart with `applyMoreData`.

## Why ? 
Because most of the brokers/exchanges websockets provide tick-by-tick refreshes. Binance for example, or Polygon, Questrade ... 


## API
First, the user must give the Timeframe of his graph in milliseconds: 
Example, for 5 minutes:
```
kLineChart.setIntervalMs(5 * 60 * 1000)
```

Now, we can add ticks instead of candles : 
```
this.klineChart.applyMoreData({
     timestamp,
     price: 15402.21,
     volume: 2
})
```

As this is my first PR on the project, I suggest that you do not hesitate to send me your comments and I will make the necessary corrections.