### PR TITLE
feat: Ability to calculate technical indicator async

### DIFF
--- a/src/component/technicalindicator/TechnicalIndicator.js
+++ b/src/component/technicalindicator/TechnicalIndicator.js
@@ -227,8 +227,8 @@ export default class TechnicalIndicator {
    * @param dataList
    * @return {*}
    */
-  calc (dataList) {
-    this.result = this.calcTechnicalIndicator(dataList, {
+  async calc (dataList) {
+    this.result = await this.calcTechnicalIndicator(dataList, {
       params: this._createParams(this.calcParams),
       plots: this.plots
     }) || []

--- a/types/TechnicalIndicator.d.ts
+++ b/types/TechnicalIndicator.d.ts
@@ -51,7 +51,7 @@ export declare interface TechnicalIndicatorRenderParams {
 }
 
 export declare interface TechnicalIndicatorTemplate extends TechnicalIndicator {
-  calcTechnicalIndicator: (kLineDataList: KLineData[], options?: any) => any[];
+  calcTechnicalIndicator: (kLineDataList: KLineData[], options?: any) => any[] | Promise<any[]>;
   series?: TechnicalIndicatorSeries;
   plots?: TechnicalIndicatorPlot[];
   shouldCheckParamCount?: boolean;


### PR DESCRIPTION
This feature adds ability to calculate technical indicator values in a separate backend service or even just in a webworker. Added due to perfomance reasons.
![image](https://user-images.githubusercontent.com/6934028/148805548-2d97682b-cbae-49a6-84e8-4b22c03a16d5.png)
