### PR TITLE
Allow negative values in an indicator parameters

### DIFF
--- a/src/component/technicalindicator/TechnicalIndicator.js
+++ b/src/component/technicalindicator/TechnicalIndicator.js
@@ -175,7 +175,6 @@ export default class TechnicalIndicator {
       }
       if (
         !isNumber(v) ||
-        v <= 0 ||
         (!allowDecimal && parseInt(v, 10) !== v)
       ) {
         return false


### PR DESCRIPTION
I want to have the ability to set negative values in an indicator parameters. For example I have an volume indicator with a negative parameter value
<img width="309" alt="image" src="https://user-images.githubusercontent.com/6934028/152639732-7a4ec828-a58a-48ae-8dfd-9736cd0d7588.png">
 