### PR TITLE
setShapeOptions新增points参数，实现点移动

### DIFF
--- a/src/component/overlay/Shape.js
+++ b/src/component/overlay/Shape.js
@@ -114,6 +114,7 @@ export default class Shape extends Overlay {
   /**
    * 加载点
    * @param points
+   * @return {undefined|boolean}
    */
   setPoints (points) {
     if (isArray(points) && points.length > 0) {
@@ -148,6 +149,8 @@ export default class Shape extends Overlay {
           yAxis: this._yAxis
         })
       }
+      // 设置点后需要重绘，返回重绘标识
+      return true
     }
   }
 

--- a/src/extension/shape/priceLine.js
+++ b/src/extension/shape/priceLine.js
@@ -20,7 +20,8 @@ export default {
   checkEventCoordinateOnShape: ({ dataSource, eventCoordinate }) => {
     return checkCoordinateOnRayLine(dataSource[0], dataSource[1], eventCoordinate)
   },
-  createShapeDataSource: ({ coordinates, viewport, precision, yAxis }) => {
+  createShapeDataSource: ({ coordinates, viewport, precision, points }) => {
+    const { value } = points[0]
     return [
       {
         type: 'line',
@@ -33,7 +34,7 @@ export default {
         isDraw: true,
         isCheck: false,
         dataSource: [
-          { x: coordinates[0].x, y: coordinates[0].y, text: yAxis.convertFromPixel(coordinates[0].y).toFixed(precision.price) }
+          { x: coordinates[0].x, y: coordinates[0].y, text: value.toFixed(precision.price) }
         ]
       }
     ]

--- a/src/store/ShapeStore.js
+++ b/src/store/ShapeStore.js
@@ -254,8 +254,7 @@ export default class ShapeStore {
     const apply = instance => {
       instance.setLock(lock)
       instance.setMode(mode)
-      instance.setPoints(points)
-      if (instance.setStyles(styles, defaultStyles) || instance.setData(data)) {
+      if (instance.setStyles(styles, defaultStyles) || instance.setData(data) || instance.setPoints(points)) {
         shouldInvalidate = true
       }
     }

--- a/src/store/ShapeStore.js
+++ b/src/store/ShapeStore.js
@@ -248,28 +248,22 @@ export default class ShapeStore {
    * @param options
    */
   setInstanceOptions (options = {}) {
-    const { id, styles, lock, mode, data } = options
+    const { id, styles, lock, mode, data, points } = options
     const defaultStyles = this._chartStore.styleOptions().shape
     let shouldInvalidate = false
+    const apply = instance => {
+      instance.setLock(lock)
+      instance.setMode(mode)
+      instance.setPoints(points)
+      if (instance.setStyles(styles, defaultStyles) || instance.setData(data)) {
+        shouldInvalidate = true
+      }
+    }
     if (isValid(id)) {
       const instance = this.getInstance(id)
-      if (instance) {
-        instance.setLock(lock)
-        instance.setMode(mode)
-        if (instance.setStyles(styles, defaultStyles) || instance.setData(data)) {
-          shouldInvalidate = true
-        }
-      }
+      instance && apply(instance)
     } else {
-      this._instances.forEach(shapes => {
-        shapes.forEach(instance => {
-          instance.setLock(lock)
-          instance.setMode(mode)
-          if (instance.setStyles(styles, defaultStyles) || instance.setData(data)) {
-            shouldInvalidate = true
-          }
-        })
-      })
+      this._instances.forEach(shapes =>shapes.forEach(apply))
     }
     if (shouldInvalidate) {
       this._chartStore.invalidate(InvalidateLevel.OVERLAY)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -149,6 +149,7 @@ declare namespace klinecharts {
   
   interface OverrideShape {
     id?: string;
+    points?: Point[];
     styles?: any;
     lock?: boolean;
     mode?: ShapeMode;
@@ -157,7 +158,6 @@ declare namespace klinecharts {
   
   interface Shape extends OverrideShape {
     name: string;
-    points?: Point[];
     onDrawStart?: (event: ShapeEvent) => void;
     onDrawing?: (event: ShapeEvent) => void;
     onDrawEnd?: (event: ShapeEvent) => void;


### PR DESCRIPTION
还附加合并了一下重复代码，使打包体积更小一些。
本地测试了一下，确实可以工作，比如
`            <Button onClick={() => {
                const value = 40 + Math.random() * 18
                chart?.setShapeOptions({ id: "shape_1", points: [{ "timestamp": 1655967600000, "value": value }] })
            }}>
`