### PR TITLE
fix: 容器尺寸突变时渲染不正确

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -266,6 +266,9 @@ export default class ChartImp implements Chart {
     }
     if (forceMeasureWidth) {
       this._measurePaneWidth()
+      this._panes.forEach(pane => {
+        pane.getAxisComponent().buildTicks(forceAdjustYAxis)
+      })
     }
     if (shouldUpdate ?? false) {
       this._xAxisPane.getAxisComponent().buildTicks(true)


### PR DESCRIPTION
_measurePaneWidth 方法会改变 visibleDataList，但是没有重新计算 _extremum，导致某些情况显示错误，例如：
打开 [https://klinecharts.com/zh-CN/sample](https://klinecharts.com/zh-CN/sample)，打开控制台，拖动一定的范围，然后取消控制台，这个时候就会发现 k线展示错误，重新拖动下k线变为正常。