### PR TITLE
新增overlayStore双击接口

### DIFF
--- a/src/component/Overlay.ts
+++ b/src/component/Overlay.ts
@@ -44,7 +44,7 @@ export interface OverlayPerformEventParams {
   performPoint: Partial<Point>
 }
 
-export type OverlayFigureIgnoreEventType = 'mouseClickEvent' | 'mouseRightClickEvent' | 'tapEvent' | 'mouseDownEvent' | 'touchStartEvent' | 'mouseMoveEvent' | 'touchMoveEvent'
+export type OverlayFigureIgnoreEventType = 'mouseClickEvent' | 'mouseRightClickEvent' | 'tapEvent' | 'mouseDownEvent' | 'touchStartEvent' | 'mouseMoveEvent' | 'touchMoveEvent' | 'mouseDoubleClickEvent'
 
 export function getAllOverlayFigureIgnoreEventTypes (): OverlayFigureIgnoreEventType[] {
   return [
@@ -221,6 +221,11 @@ export interface Overlay {
   onClick: Nullable<OverlayEventCallback>
 
   /**
+   * db Click event
+   */
+  ondbClick: Nullable<OverlayEventCallback>
+
+  /**
    * Right click event
    */
   onRightClick: Nullable<OverlayEventCallback>
@@ -307,6 +312,7 @@ export default abstract class OverlayImp implements Overlay {
   onDrawing: Nullable<OverlayEventCallback>
   onDrawEnd: Nullable<OverlayEventCallback>
   onClick: Nullable<OverlayEventCallback>
+  ondbClick: Nullable<OverlayEventCallback>
   onRightClick: Nullable<OverlayEventCallback>
   onPressedMoveStart: Nullable<OverlayEventCallback>
   onPressedMoving: Nullable<OverlayEventCallback>
@@ -328,7 +334,7 @@ export default abstract class OverlayImp implements Overlay {
       createPointFigures, createXAxisFigures, createYAxisFigures,
       performEventPressedMove, performEventMoveForDrawing,
       onDrawStart, onDrawing, onDrawEnd,
-      onClick, onRightClick,
+      onClick, ondbClick, onRightClick,
       onPressedMoveStart, onPressedMoving, onPressedMoveEnd,
       onMouseEnter, onMouseLeave, onRemoved,
       onSelected, onDeselected
@@ -353,6 +359,7 @@ export default abstract class OverlayImp implements Overlay {
     this.onDrawing = onDrawing ?? null
     this.onDrawEnd = onDrawEnd ?? null
     this.onClick = onClick ?? null
+    this.ondbClick = ondbClick ?? null
     this.onRightClick = onRightClick ?? null
     this.onPressedMoveStart = onPressedMoveStart ?? null
     this.onPressedMoving = onPressedMoving ?? null
@@ -508,6 +515,14 @@ export default abstract class OverlayImp implements Overlay {
   setOnClickCallback (callback: Nullable<OverlayEventCallback>): boolean {
     if (this.onClick !== callback) {
       this.onClick = callback
+      return true
+    }
+    return false
+  }
+
+  setOndbClickCallback (callback: Nullable<OverlayEventCallback>): boolean {
+    if (this.ondbClick !== callback) {
+      this.ondbClick = callback
       return true
     }
     return false

--- a/src/store/OverlayStore.ts
+++ b/src/store/OverlayStore.ts
@@ -102,7 +102,7 @@ export default class OverlayStore {
     const {
       id, groupId, points, styles, lock, visible, zLevel, mode, extendData,
       onDrawStart, onDrawing,
-      onDrawEnd, onClick, onRightClick,
+      onDrawEnd, onClick, ondbClick, onRightClick,
       onPressedMoveStart, onPressedMoving, onPressedMoveEnd,
       onMouseEnter, onMouseLeave,
       onRemoved, onSelected, onDeselected
@@ -148,6 +148,9 @@ export default class OverlayStore {
     }
     if (onClick !== undefined) {
       instance.setOnClickCallback(onClick)
+    }
+    if (ondbClick !== undefined) {
+      instance.setOndbClickCallback(ondbClick)
     }
     if (onRightClick !== undefined) {
       instance.setOnRightClickCallback(onRightClick)
@@ -458,6 +461,26 @@ export default class OverlayStore {
     const { paneId, instance, figureType, figureKey, figureIndex } = this._clickInstanceInfo
     if (!(info.instance?.isDrawing() ?? false)) {
       info.instance?.onClick?.({ overlay: info.instance, figureKey: info.figureKey, figureIndex: info.figureIndex, ...event })
+    }
+    if (instance?.id !== info.instance?.id || figureType !== info.figureType || figureIndex !== info.figureIndex) {
+      this._clickInstanceInfo = info
+      if (instance?.id !== info.instance?.id) {
+        instance?.onDeselected?.({ overlay: instance, figureKey, figureIndex, ...event })
+        info.instance?.onSelected?.({ overlay: info.instance, figureKey: info.figureKey, figureIndex: info.figureIndex, ...event })
+        const chart = this._chartStore.getChart()
+        chart.updatePane(UpdateLevel.Overlay, info.paneId)
+        if (paneId !== info.paneId) {
+          chart.updatePane(UpdateLevel.Overlay, paneId)
+        }
+        chart.updatePane(UpdateLevel.Overlay, PaneIdConstants.XAXIS)
+      }
+    }
+  }
+
+  setdbClickInstanceInfo (info: EventOverlayInfo, event: MouseTouchEvent): void {
+    const { paneId, instance, figureType, figureKey, figureIndex } = this._clickInstanceInfo
+    if (!(info.instance?.isDrawing() ?? false)) {
+      info.instance?.ondbClick?.({ overlay: info.instance, figureKey: info.figureKey, figureIndex: info.figureIndex, ...event })
     }
     if (instance?.id !== info.instance?.id || figureType !== info.figureType || figureIndex !== info.figureIndex) {
       this._clickInstanceInfo = info

--- a/src/view/OverlayView.ts
+++ b/src/view/OverlayView.ts
@@ -107,6 +107,9 @@ export default class OverlayView<C extends Axis = YAxis> extends View<C> {
       return false
     }).registerEvent('mouseDoubleClickEvent', (event: MouseTouchEvent) => {
       const progressInstanceInfo = overlayStore.getProgressInstanceInfo()
+      // const overlay = progressInstanceInfo?.instance
+      // const index = overlay?.points?.length?- 1
+      // const key = `${OVERLAY_FIGURE_KEY_PREFIX}point_${index}`
       if (progressInstanceInfo !== null) {
         const overlay = progressInstanceInfo.instance
         const progressInstancePaneId = progressInstanceInfo.paneId
@@ -119,8 +122,19 @@ export default class OverlayView<C extends Axis = YAxis> extends View<C> {
             overlay.onDrawEnd?.({ overlay, figureKey: key, figureIndex: index, ...event })
           }
         }
-        return true
+        const index = overlay.points.length - 1
+        return this._figureMouseClickEvent(
+          overlay,
+          EventOverlayInfoFigureType.Point,
+          `${OVERLAY_FIGURE_KEY_PREFIX}point_${index}`,
+          index,
+          0
+        )(event)
       }
+      overlayStore.setdbClickInstanceInfo({
+        paneId, instance: null, figureType: EventOverlayInfoFigureType.None, figureKey: '', figureIndex: -1, attrsIndex: -1
+      }, event)
+
       return false
     }).registerEvent('mouseRightClickEvent', (event: MouseTouchEvent) => {
       const progressInstanceInfo = overlayStore.getProgressInstanceInfo()
@@ -191,7 +205,8 @@ export default class OverlayView<C extends Axis = YAxis> extends View<C> {
           mouseMoveEvent: this._figureMouseMoveEvent(overlay, figureType, figureKey, figureIndex, attrsIndex),
           mouseDownEvent: this._figureMouseDownEvent(overlay, figureType, figureKey, figureIndex, attrsIndex),
           mouseClickEvent: this._figureMouseClickEvent(overlay, figureType, figureKey, figureIndex, attrsIndex),
-          mouseRightClickEvent: this._figureMouseRightClickEvent(overlay, figureType, figureKey, figureIndex, attrsIndex)
+          mouseRightClickEvent: this._figureMouseRightClickEvent(overlay, figureType, figureKey, figureIndex, attrsIndex),
+          mouseDoubleClickEvent: this._figureMousedbClickEvent(overlay, figureType, figureKey, figureIndex, attrsIndex)
         }
       }
       eventHandler = {}
@@ -210,6 +225,9 @@ export default class OverlayView<C extends Axis = YAxis> extends View<C> {
       }
       if (!eventTypes.includes('mouseRightClickEvent')) {
         eventHandler.mouseRightClickEvent = this._figureMouseRightClickEvent(overlay, figureType, figureKey, figureIndex, attrsIndex)
+      }
+      if (!eventTypes.includes('mouseDoubleClickEvent')) {
+        eventHandler.mouseDoubleClickEvent = this._figureMousedbClickEvent(overlay, figureType, figureKey, figureIndex, attrsIndex)
       }
     }
     return eventHandler
@@ -244,6 +262,16 @@ export default class OverlayView<C extends Axis = YAxis> extends View<C> {
       const paneId = pane.getId()
       const overlayStore = pane.getChart().getChartStore().getOverlayStore()
       overlayStore.setClickInstanceInfo({ paneId, instance: overlay, figureType, figureKey, figureIndex, attrsIndex }, event)
+      return true
+    }
+  }
+
+  private _figureMousedbClickEvent (overlay: Overlay, figureType: EventOverlayInfoFigureType, figureKey: string, figureIndex: number, attrsIndex: number): MouseTouchEventCallback {
+    return (event: MouseTouchEvent) => {
+      const pane = this.getWidget().getPane()
+      const paneId = pane.getId()
+      const overlayStore = pane.getChart().getChartStore().getOverlayStore()
+      overlayStore.setdbClickInstanceInfo({ paneId, instance: overlay, figureType, figureKey, figureIndex, attrsIndex }, event)
       return true
     }
   }


### PR DESCRIPTION
在覆盖物中新增ondbClick接口
`ondbClick:(event: OverlayEvent)=>{
    console.log('db click')
    event.overlay.lock = false;
    return true;
  },`