### PR TITLE
Fix blur on low DPI screens

### DIFF
--- a/src/extension/figure/text.ts
+++ b/src/extension/figure/text.ts
@@ -62,6 +62,9 @@ export function getTextRect (attrs: TextAttrs, styles: Partial<RectTextStyle>, t
       break
     }
   }
+  startX = Math.round(startX) + 0.5
+  startY = Math.round(startY) + 0.5
+
   return { x: startX, y: startY, width: paddingLeft + textWidth + paddingRight, height: paddingTop + textHeight + paddingBottom }
 }
 
@@ -76,7 +79,7 @@ export function checkCoordinateOnText (coordinate: Coordinate, attrs: TextAttrs,
 }
 
 export function drawText (ctx: CanvasRenderingContext2D, attrs: TextAttrs, styles: Partial<TextStyle>): void {
-  const { x, y, text, align = 'left', baseline = 'top' } = attrs
+  let { x, y, text, align = 'left', baseline = 'top' } = attrs
   const {
     color = 'currentColor',
     size = 12,
@@ -85,6 +88,9 @@ export function drawText (ctx: CanvasRenderingContext2D, attrs: TextAttrs, style
   ctx.textAlign = align
   ctx.textBaseline = baseline
   ctx.font = createFont(size, weight, family)
+
+  x = Math.round(x) + 0.5
+  y = Math.round(y) + 0.5
 
   ctx.fillStyle = color
   ctx.fillText(text, x, y)

--- a/src/store/TimeScaleStore.ts
+++ b/src/store/TimeScaleStore.ts
@@ -124,8 +124,12 @@ export default class TimeScaleStore {
   private _calcGapBarSpace (): number {
     const rateSpace = Math.floor(this._barSpace * 0.82)
     const floorSpace = Math.floor(this._barSpace)
-    const optimalSpace = Math.min(rateSpace, floorSpace - 1)
-    return Math.max(1, optimalSpace)
+    let optimalSpace = Math.min(rateSpace, floorSpace - 1)
+    // If the optimal space is an odd number halfGapBar will be x.5, which will cause blur fix to fail
+    if (optimalSpace % 2 !== 0) {
+      optimalSpace -= 1
+    }
+    return Math.max(2, optimalSpace)
   }
 
   /**

--- a/src/store/TimeScaleStore.ts
+++ b/src/store/TimeScaleStore.ts
@@ -330,7 +330,7 @@ export default class TimeScaleStore {
   dataIndexToCoordinate (dataIndex: number): number {
     const dataCount = this._chartStore.getDataList().length
     const deltaFromRight = dataCount + this._offsetRightBarCount - dataIndex
-    return this._totalBarSpace - (deltaFromRight - 0.5) * this._barSpace
+    return Math.floor(this._totalBarSpace - (deltaFromRight - 0.5) * this._barSpace)
   }
 
   coordinateToDataIndex (x: number): number {

--- a/src/view/CandleBarView.ts
+++ b/src/view/CandleBarView.ts
@@ -107,7 +107,7 @@ export default class CandleBarView extends ChildrenView {
         name: 'rect',
         attrs: {
           x: x - 0.5,
-          y: priceY[0],
+          y: priceY[0] - 0.5,
           width: 1,
           height: priceY[1] - priceY[0]
         },
@@ -122,7 +122,7 @@ export default class CandleBarView extends ChildrenView {
           name: 'rect',
           attrs: {
             x: x - halfGapBar + 0.5,
-            y: priceY[1],
+            y: priceY[1] + 0.5,
             width: gapBar - 1,
             height: barHeight
           },
@@ -136,7 +136,7 @@ export default class CandleBarView extends ChildrenView {
           name: 'rect',
           attrs: {
             x: x - halfGapBar + 0.5,
-            y: priceY[1],
+            y: priceY[1] + 0.5,
             width: gapBar - 1,
             height: barHeight
           },
@@ -151,7 +151,7 @@ export default class CandleBarView extends ChildrenView {
         name: 'rect',
         attrs: {
           x: x - 0.5,
-          y: priceY[2],
+          y: priceY[2] - 0.5,
           width: 1,
           height: priceY[3] - priceY[2]
         },


### PR DESCRIPTION
Fixing issues:
 - https://github.com/liihuu/KLineChart/issues/452
 - https://github.com/liihuu/KLineChart/issues/258

After debugging I found bars rendering with X values like: 1234.345639857, it give nice smooth zoom but trigger anti aliasing on low DPI screens, it does not affect a lot of zooming and it still feels quite smooth. Aligning also works as before.