### PR TITLE
Solid candle reducing figures count and complexity

### DIFF
--- a/src/extension/figure/index.ts
+++ b/src/extension/figure/index.ts
@@ -23,10 +23,11 @@ import rect from './rect'
 import text from './text'
 import rectText from './rectText'
 import arc from './arc'
+import wick from './wick'
 
 const figures: Record<string, FigureInnerConstructor> = {}
 
-const extensions = [circle, line, polygon, rect, text, rectText, arc]
+const extensions = [circle, line, polygon, rect, text, rectText, arc, wick]
 extensions.forEach((figure: FigureTemplate) => {
   figures[figure.name] = FigureImp.extend(figure)
 })

--- a/src/extension/figure/wick.ts
+++ b/src/extension/figure/wick.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+
+ * http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Coordinate from '../../common/Coordinate'
+import { LineStyle } from '../../common/Options'
+
+import { FigureTemplate, DEVIATION } from '../../component/Figure'
+
+export function checkCoordinateOnWick (coordinate: Coordinate, line: WickAttrs): boolean {
+  const coordinates = line.coordinates
+  if (coordinates.length > 1) {
+    for (let i = 1; i < coordinates.length; i++) {
+      const prevCoordinate = coordinates[i - 1]
+      const currentCoordinate = coordinates[i]
+      if (prevCoordinate.x === currentCoordinate.x) {
+        if (
+          Math.abs(prevCoordinate.y - coordinate.y) + Math.abs(currentCoordinate.y - coordinate.y) - Math.abs(prevCoordinate.y - currentCoordinate.y) < DEVIATION + DEVIATION &&
+          Math.abs(coordinate.x - prevCoordinate.x) < DEVIATION
+        ) {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+export function drawWick (ctx: CanvasRenderingContext2D, attrs: WickAttrs, styles: Partial<LineStyle>): void {
+  const { coordinates } = attrs
+  const length = coordinates.length
+  if (length > 1) {
+    const { size = 1, color = 'currentColor' } = styles
+    ctx.lineWidth = size
+    ctx.strokeStyle = color
+    ctx.setLineDash([])
+    ctx.beginPath()
+    ctx.moveTo(coordinates[0].x, coordinates[0].y)
+    ctx.lineTo(coordinates[1].x, coordinates[1].y)
+    ctx.stroke()
+    ctx.closePath()
+  }
+}
+
+export interface WickAttrs {
+  coordinates: Coordinate[]
+}
+
+const line: FigureTemplate<WickAttrs, Partial<LineStyle>> = {
+  name: 'wick',
+  checkEventOn: checkCoordinateOnWick,
+  draw: (ctx: CanvasRenderingContext2D, attrs: WickAttrs, styles: Partial<LineStyle>) => {
+    drawWick(ctx, attrs, styles)
+  }
+}
+
+export default line

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import {
   checkCoordinateOnLine, drawLine,
   getLinearYFromSlopeIntercept, getLinearSlopeIntercept, getLinearYFromCoordinates
 } from './extension/figure/line'
+import { checkCoordinateOnWick, drawWick } from './extension/figure/wick'
 import { checkCoordinateOnPolygon, drawPolygon } from './extension/figure/polygon'
 import { checkCoordinateOnRect, drawRect } from './extension/figure/rect'
 import { drawRectText } from './extension/figure/rectText'
@@ -151,13 +152,15 @@ const utils = {
   checkCoordinateOnPolygon,
   checkCoordinateOnRect,
   checkCoordinateOnText,
+  checkCoordinateOnWick,
   drawArc,
   drawCircle,
   drawLine,
   drawPolygon,
   drawRect,
   drawText,
-  drawRectText
+  drawRectText,
+  drawWick
 }
 
 export {

--- a/src/view/CandleBarView.ts
+++ b/src/view/CandleBarView.ts
@@ -25,6 +25,7 @@ import Axis from '../component/Axis'
 
 import { FigureCreate } from '../component/Figure'
 import { RectAttrs } from '../extension/figure/rect'
+import { WickAttrs } from '../extension/figure/wick'
 
 import ChildrenView from './ChildrenView'
 
@@ -101,24 +102,25 @@ export default class CandleBarView extends ChildrenView {
 
     const barHeight = Math.max(1, priceY[2] - priceY[1])
 
-    let rects: Array<FigureCreate<RectAttrs, Partial<RectStyle>>> = []
+    let figures: Array<FigureCreate<RectAttrs | WickAttrs, Partial<RectStyle>>> = []
     if (type !== CandleType.Ohlc) {
-      rects.push({
-        name: 'rect',
-        attrs: {
-          x: x - 0.5,
-          y: priceY[0],
-          width: 1,
-          height: priceY[1] - priceY[0]
-        },
-        styles: { color: wickColor }
-      })
       if (
         type === CandleType.CandleStroke ||
         (type === CandleType.CandleUpStroke && open < close) ||
         (type === CandleType.CandleDownStroke && open > close)
       ) {
-        rects.push({
+        figures.push({
+          name: 'rect',
+          attrs: {
+            x: x - 0.5,
+            y: priceY[0],
+            width: 1,
+            height: priceY[1] - priceY[0]
+          },
+          styles: { color: wickColor }
+        })
+
+        figures.push({
           name: 'rect',
           attrs: {
             x: x - halfGapBar + 0.5,
@@ -131,8 +133,19 @@ export default class CandleBarView extends ChildrenView {
             borderColor
           }
         })
+
+        figures.push({
+          name: 'rect',
+          attrs: {
+            x: x - 0.5,
+            y: priceY[2],
+            width: 1,
+            height: priceY[3] - priceY[2]
+          },
+          styles: { color: wickColor }
+        })
       } else {
-        rects.push({
+        figures.push({
           name: 'rect',
           attrs: {
             x: x - halfGapBar + 0.5,
@@ -146,19 +159,20 @@ export default class CandleBarView extends ChildrenView {
             borderColor
           }
         })
+
+        figures.push({
+          name: 'wick',
+          attrs: {
+            coordinates: [
+              { x, y: priceY[0] },
+              { x, y: priceY[3] }
+            ]
+          },
+          styles: { color: wickColor }
+        })
       }
-      rects.push({
-        name: 'rect',
-        attrs: {
-          x: x - 0.5,
-          y: priceY[2],
-          width: 1,
-          height: priceY[3] - priceY[2]
-        },
-        styles: { color: wickColor }
-      })
     } else {
-      rects = [
+      figures = [
         {
           name: 'rect',
           attrs: {
@@ -189,14 +203,14 @@ export default class CandleBarView extends ChildrenView {
         }
       ]
     }
-    rects.forEach(({ attrs, styles }) => {
+    figures.forEach(({ name, attrs, styles }) => {
       let handler: EventHandler | undefined
       if (isMain) {
         handler = {
           mouseClickEvent: this._boundCandleBarClickEvent(data)
         }
       }
-      this.createFigure('rect', attrs, styles, handler)?.draw(ctx)
+      this.createFigure(name, attrs, styles, handler)?.draw(ctx)
     })
   }
 }


### PR DESCRIPTION
Instead of 3 figures per solid candle I reduced it to only 2 figures (body - rect and wick - line). 

Line figure is quite heavy with logic for lines on angle, so I added very simple Wick figure with minimum logic behind to improve further  performance. it's not necessary and can be replaced back with the line figure to save some bundle size, but should be very small increase. But removing loop from wick figure always a good idea for big dataset.